### PR TITLE
Adjust homepage headings

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -30,8 +30,8 @@
         <li class="{{ product.css_class }}">
           <a href="{{ product.url }}">
             <img alt="Image of {{ product.name | escape }}" src="{{ product.image | product_image_url | constrain: 600, 600 }}">
-            <h4 class="product_name">{{ product.name }}</h4>
-            <h5>{{ product.default_price | money: theme.money_format }}</h5>
+            <div class="product_name">{{ product.name }}</div>
+            <div class="product_price">{{ product.default_price | money: theme.money_format }}</div>
   					{% case product.status %}
   						{% when 'active' %}
   							{% if product.on_sale %}<span class="status">On Sale</span>{% endif %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -44,7 +44,7 @@
           <span class="cart_numbers">{{ cart.total | money: theme.money_format }}</span>
         </a>
         <div class="side_categories">
-          <h3>Shop</h3>
+          <h2>Shop</h2>
           <ul>
             <li><a href="/products">All Products</a></li>
             {% if theme.show_search %}
@@ -63,7 +63,7 @@
         </div>
         {% if artists.active != blank %}
           <div class="side_artists">
-            <h3>Artists</h3>
+            <h2>Artists</h2>
             <ul>
               {% for artist in artists.active %}
                 <li>{{ artist | link_to }}</li>
@@ -75,7 +75,7 @@
           {% get 5 products from products.all order: 'newest' %}
             {% if products != blank %}
               <div class="side_pages">
-                <h3>Newest Products</h3>
+                <h2>Newest Products</h2>
                 <ul>
                 	{% for product in products %}
                 	  <li>{{ product | link_to }}</li>
@@ -89,7 +89,7 @@
           {% get 5 products from products.all order: 'sales' %}
             {% if products != blank %}
               <div class="side_pages">
-                <h3>Top Selling</h3>
+                <h2>Top Selling</h2>
                 <ul>
                 	{% for product in products %}
                 	  <li>{{ product | link_to }}</li>
@@ -100,7 +100,7 @@
           {% endget %}
         {% endif %}
         <div class="side_pages">
-          <h3>Pages</h3>
+          <h2>Pages</h2>
           <ul>
             {% for page in pages.all %}
             	<li>{{ page | link_to }}</li>

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -308,7 +308,7 @@ aside
     visibility: visible
     z-index: 9
 
-  h3
+  h2
     border-bottom: 1px solid $border-color
     font-size: 17px
     line-height: 1.3em

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -36,17 +36,18 @@ ul.products
         
       &:hover img
         opacity: .85
-          
-      h4
+
+      .product_name
         +all-transitions
+        color: $header-color
         font-size: 14px
         line-height: 1.3em
         margin-top: 10px
-        
-      &:hover h4
+
+      &:hover .product_name
         color: $hover-color
-        
-      h5
+
+      .product_price
         +all-transitions
         color: $text-color
         display: inline-block


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169551981

This remove headings from product name and price because by nature, headings organizes passages of text. The product name and price do not have related passages of text and by itself are its own entity, so I have switched them to be encased in divs instead.

This also reassigns heading levels for the navigation headings. Headings were assigned to be h3 when there were no h2. Heading levels should only increase by one.