### PR TITLE
Set empty alt attribute for product images

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -29,7 +29,7 @@
         {% for product in products %}
         <li class="{{ product.css_class }}">
           <a href="{{ product.url }}">
-            <img alt="Image of {{ product.name | escape }}" src="{{ product.image | product_image_url | constrain: 600, 600 }}">
+            <img alt="" src="{{ product.image | product_image_url | constrain: 600, 600 }}">
             <div class="product_name">{{ product.name }}</div>
             <div class="product_price">{{ product.default_price | money: theme.money_format }}</div>
   					{% case product.status %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -21,7 +21,7 @@
   		<div class="wrap">
         <a href="/" title="{{ store.name | escape }}" class="store_header {% if theme.header_logo != blank %}logo{% else %}text{% endif %}">
       		{% if theme.header_logo != blank %}
-      			<img src="{{ theme.images.header_logo.url | constrain: 1300, 250 }}" alt="{{ store.name }}">
+      			<img src="{{ theme.images.header_logo.url | constrain: 1300, 250 }}" alt="{{ store.name }} Home">
       		{% else %}
       			{{ store.name }}
       		{% endif %}


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169551543

Since product images are functional images, a defined alt tag is not needed.