### PR TITLE
Add "contentinfo" role to footer

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -113,7 +113,7 @@
         </div>
       </aside>
     </div>
-    <footer>
+    <footer role="contentinfo">
       <div class="wrapper">
         <div class="footer_left">
   	  	  {{ bigcartel_credit }}


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169633856

This addresses a bug in Apple VoiceOver where the footer content isn't announced. Assigning it a role of "contentinfo" allows VoiceOver to recognize it as a footer.