### PR TITLE
Set empty alt attribute to product list product images

### DIFF
--- a/source/products.html
+++ b/source/products.html
@@ -5,7 +5,7 @@
       {% for product in products %}
       <li class="{{ product.css_class }}">
         <a href="{{ product.url }}">
-          <img alt="Image of {{ product.name | escape }}" src="{{ product.image | product_image_url | constrain: 600, 600  }}">
+          <img alt="" src="{{ product.image | product_image_url | constrain: 600, 600  }}">
           <h4 class="product_name">{{ product.name }}</h4>
           <h5>{{ product.default_price | money: theme.money_format }}</h5>
 					{% case product.status %}


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169552670

Since product images are functional images, a defined alt attribute is not needed