### PR TITLE
Remove heading from product price/status

### DIFF
--- a/source/product.html
+++ b/source/product.html
@@ -1,6 +1,6 @@
 <section class="product_pricing">
   <h1>{{ page.name }}</h1>
-  <h2>
+  <div class="product_price_status">
     <span class="product_price">
       {% if product.variable_pricing %}
         {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
@@ -16,7 +16,7 @@
 			{% when 'coming-soon' %}
 				<span class="small_status {{ product.css_class }}">Coming soon</span>
 		{% endcase %}
-	</h2>
+	</div>
 </section>
 <section class="product_images">
 	<a href="{{ product.image | product_image_url }}"><img src="{{ product.image | product_image_url }}" alt="Image of {{ product.name | escape }}" class="primary_image"></a>

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -59,7 +59,7 @@
     margin: -.2em 0 5px
     min-height: 0
 
-  h2
+  .product_price_status
     color: $text-color
     font-family: $secondary-font
     font-size: 17px


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169553005

Since product price/status does not have related sub-content, using a heading element does not make the most sense. Instead, I've replaced it with a div.