### PR TITLE
Remove "Image of" from product image alt attributes

### DIFF
--- a/source/product.html
+++ b/source/product.html
@@ -19,11 +19,11 @@
 	</h2>
 </section>
 <section class="product_images">
-	<a href="{{ product.image | product_image_url }}"><img src="{{ product.image | product_image_url }}" alt="Image of {{ product.name | escape }}" class="primary_image"></a>
+	<a href="{{ product.image | product_image_url }}"><img src="{{ product.image | product_image_url }}" alt="{{ product.name | escape }}" class="primary_image"></a>
 	{% if product.images.size > 1 %}
   	<ul class="product_thumbnails">
   	{% for image in product.images offset: 1 %}
-  	  <li><a href="{{ image | product_image_url }}"><img src="{{ image | product_image_url | constrain: 300 }}" alt="Image of {{ product.name | escape }}"></a></li>
+  	  <li><a href="{{ image | product_image_url }}"><img src="{{ image | product_image_url | constrain: 300 }}" alt="{{ product.name | escape }}"></a></li>
   	{% endfor %}
   	</ul>
 	{% endif %}


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169552957

Prepending the alt attribute with "Image of..." is redundant since most screen readers already announce that it is an image. This modifies the alt attribute to be assigned to the product name only.