### PR TITLE
Remove redundant title attribute from add to cart button

### DIFF
--- a/source/product.html
+++ b/source/product.html
@@ -68,7 +68,7 @@
           </div>
         {% endif %}
       {% endif %}
-      <button class="button add-to-cart-button" name="submit" type="submit" title="Add to Cart" data-add-title="Add to Cart" data-sold-title="Sold out"{% if product.has_default_option %}{% else %}disabled="disabled"{% endif %}>Add to Cart</button>
+      <button class="button add-to-cart-button" name="submit" type="submit" data-add-title="Add to Cart" data-sold-title="Sold out"{% if product.has_default_option %}{% else %}disabled="disabled"{% endif %}>Add to Cart</button>
       {{ store | instant_checkout_button: 'dark', '44px' }}
       {% if product.has_option_groups %}
         <div class="reset-selection-button-container">


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169552973

It is recommended to remove title attributes that are redundant/identical to the element's text. In this case, the button text and title text both say "Add to Cart" rendering the title text unnecessary.