### PR TITLE
Add labels to cart-specific icons

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -26,7 +26,7 @@
             <div class="quantity">{{ item | item_quantity_input }}</div>
             <div class="price">{{ item.price | money: theme.money_format }}</div>
             <div class="remove">
-              <a href="#" data-item-id="{{ item.id }}"><svg class="remove_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14.1 14.1" enable-background="new 0 0 14.1 14.1"><path d="M14.1 1.1l-1.1-1.1-6 6-5.9-6-1.1 1.1 6 5.9-6 6 1.1 1.1 5.9-6 6 6 1.1-1.1-6-6z"/></svg></a>
+              <a href="#" data-item-id="{{ item.id }}" title="Remove Item" aria-label="Remove Item"><svg aria-hidden="true" class="remove_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14.1 14.1" enable-background="new 0 0 14.1 14.1"><path d="M14.1 1.1l-1.1-1.1-6 6-5.9-6-1.1 1.1 6 5.9-6 6 1.1 1.1 5.9-6 6 6 1.1-1.1-6-6z"/></svg></a>
             </div>
           </div>
         </li>

--- a/source/layout.html
+++ b/source/layout.html
@@ -15,7 +15,7 @@
         <span></span>
         <span></span>
       </a>
-			<a href="/cart" class="mobile_cart"><svg class="cart_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 17" enable-background="new 0 0 22 17"><path d="M4.3 0h-4.3l.5 1.4h2.8l4.2 10.9h10.5l.5-1.4h-10zM6.9 1.9l2.8 7.1h9.5l2.8-7.1h-15.1zm11.4 5.7h-7.6l-1.7-4.3h10.9l-1.6 4.3z"/><circle cx="10.2" cy="15.6" r="1.4"/><circle cx="15.6" cy="15.6" r="1.4"/></svg><span class="cart_numbers">{{ cart.item_count | pluralize: 'item', 'items' }} / {{ cart.total | money: theme.money_format }}</span></a>
+      <a href="/cart" class="mobile_cart"><svg role="img" aria-labelledby="cart-title" class="cart_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 17" enable-background="new 0 0 22 17"><title id="cart-title">View Cart</title><path d="M4.3 0h-4.3l.5 1.4h2.8l4.2 10.9h10.5l.5-1.4h-10zM6.9 1.9l2.8 7.1h9.5l2.8-7.1h-15.1zm11.4 5.7h-7.6l-1.7-4.3h10.9l-1.6 4.3z"/><circle cx="10.2" cy="15.6" r="1.4"/><circle cx="15.6" cy="15.6" r="1.4"/></svg><span class="cart_numbers">{{ cart.item_count | pluralize: 'item', 'items' }} / {{ cart.total | money: theme.money_format }}</span></a>
   	</div>
     <header class="{% if theme.header_logo != blank %}logo{% else %}text{% endif %}">
   		<div class="wrap">
@@ -40,7 +40,7 @@
         {% endif %}
       </section>
       <aside>
-        <a href="/cart" class="side_cart"><svg role="img" aria-labelledby="cart-title" class="cart_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 17" enable-background="new 0 0 22 17"><title id="cart-title">Cart</title><path d="M4.3 0h-4.3l.5 1.4h2.8l4.2 10.9h10.5l.5-1.4h-10zM6.9 1.9l2.8 7.1h9.5l2.8-7.1h-15.1zm11.4 5.7h-7.6l-1.7-4.3h10.9l-1.6 4.3z"/><circle cx="10.2" cy="15.6" r="1.4"/><circle cx="15.6" cy="15.6" r="1.4"/></svg><span class="cart_title">{{ cart.item_count | pluralize: 'item', 'items' }}</span>
+        <a href="/cart" class="side_cart" title="View Cart"><svg role="img" aria-labelledby="cart-title" class="cart_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 17" enable-background="new 0 0 22 17"><title id="cart-title">View Cart</title><path d="M4.3 0h-4.3l.5 1.4h2.8l4.2 10.9h10.5l.5-1.4h-10zM6.9 1.9l2.8 7.1h9.5l2.8-7.1h-15.1zm11.4 5.7h-7.6l-1.7-4.3h10.9l-1.6 4.3z"/><circle cx="10.2" cy="15.6" r="1.4"/><circle cx="15.6" cy="15.6" r="1.4"/></svg><span class="cart_title">{{ cart.item_count | pluralize: 'item', 'items' }}</span>
           <span class="cart_numbers">{{ cart.total | money: theme.money_format }}</span>
         </a>
         <nav role="navigation" aria-label="Main">


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169555669

This adds appropriate labels to the "Remove Item" icon. It also makes the cart icons in the sidebar and mobile menu to be more explicit about the link's role by modifying the label from "Cart" to "View Cart." 

Note: I didn't choose to go the aria-label approach for the sidebar/mobile cart icons because it would ignore descriptive information like the number of items and total price that is embedded inside the link.