### PR TITLE
Remove heading tag from cart total

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -33,7 +33,7 @@
       {% endfor %}
     </ul>
     <div class="cart_footer">
-      <h3>Total: <span>{{ cart.total | money: theme.money_format }}</span></h3>
+      <div class="cart_total">Total: <span>{{ cart.total | money: theme.money_format }}</span></div>
       <button type="submit" name="checkout" title="Checkout" class="checkout_btn">Checkout</button>
       <a class="button continue_shopping minimal-button" href="/products">Continue Shopping</a>
     </div>

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -130,7 +130,12 @@
     margin-top: 40px
     text-align: right
 
-    h3
+    .cart_total
+      color: $header-color
+      font-family: $primary-font
+      font-weight: 500
+      margin: 0
+      padding: 0
       font-size: 22px
       line-height: 22px
       margin-bottom: 40px


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169555609

Since cart total doesn't have any sub-content, it technically shouldn't be a heading. This removes the h3 tag in favor of a class-specific div.