### PR TITLE
Add focus state to product images

### DIFF
--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -7,7 +7,6 @@
 
   a
     display: block
-    outline: none
 
   @media only screen and (max-width: $break-medium)
     float: none


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169552957

Setting outline: none removes the ability for images to be focusable.
This adds it back in.