### PR TITLE
Set unique id to mobile cart title

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -15,7 +15,7 @@
         <span></span>
         <span></span>
       </a>
-      <a href="/cart" class="mobile_cart"><svg role="img" aria-labelledby="cart-title" class="cart_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 17" enable-background="new 0 0 22 17"><title id="cart-title">View Cart</title><path d="M4.3 0h-4.3l.5 1.4h2.8l4.2 10.9h10.5l.5-1.4h-10zM6.9 1.9l2.8 7.1h9.5l2.8-7.1h-15.1zm11.4 5.7h-7.6l-1.7-4.3h10.9l-1.6 4.3z"/><circle cx="10.2" cy="15.6" r="1.4"/><circle cx="15.6" cy="15.6" r="1.4"/></svg><span class="cart_numbers">{{ cart.item_count | pluralize: 'item', 'items' }} / {{ cart.total | money: theme.money_format }}</span></a>
+      <a href="/cart" class="mobile_cart"><svg role="img" aria-labelledby="cart-mobile-title" class="cart_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 17" enable-background="new 0 0 22 17"><title id="cart-mobile-title">View Cart</title><path d="M4.3 0h-4.3l.5 1.4h2.8l4.2 10.9h10.5l.5-1.4h-10zM6.9 1.9l2.8 7.1h9.5l2.8-7.1h-15.1zm11.4 5.7h-7.6l-1.7-4.3h10.9l-1.6 4.3z"/><circle cx="10.2" cy="15.6" r="1.4"/><circle cx="15.6" cy="15.6" r="1.4"/></svg><span class="cart_numbers">{{ cart.item_count | pluralize: 'item', 'items' }} / {{ cart.total | money: theme.money_format }}</span></a>
   	</div>
     <header class="{% if theme.header_logo != blank %}logo{% else %}text{% endif %}">
   		<div class="wrap">


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169555669

The desktop and mobile cart icon titles had shared ids. This changes the id for the mobile icon title so that it's unique.