### PR TITLE
Add main landmark to homepage

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -29,7 +29,7 @@
   		</div>
     </header>
     <div class="wrap">
-      <section class="content">
+      <main class="content">
         {% if page.category == 'custom' %}
           <div class="custom_content">
             <h1>{{ page.name }}</h1>
@@ -38,7 +38,7 @@
         {% else %}
           {{ page_content }}
         {% endif %}
-      </section>
+      </main>
       <aside>
         <a href="/cart" class="side_cart" title="View Cart"><svg role="img" aria-labelledby="cart-title" class="cart_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 17" enable-background="new 0 0 22 17"><title id="cart-title">View Cart</title><path d="M4.3 0h-4.3l.5 1.4h2.8l4.2 10.9h10.5l.5-1.4h-10zM6.9 1.9l2.8 7.1h9.5l2.8-7.1h-15.1zm11.4 5.7h-7.6l-1.7-4.3h10.9l-1.6 4.3z"/><circle cx="10.2" cy="15.6" r="1.4"/><circle cx="15.6" cy="15.6" r="1.4"/></svg><span class="cart_title">{{ cart.item_count | pluralize: 'item', 'items' }}</span>
           <span class="cart_numbers">{{ cart.total | money: theme.money_format }}</span>


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169736309

A main landmark provides a navigation point to the primary content of the page for users of assistive technologies. Using HTML 5 semantic markup like main, nav, footer provides landmark capabilities by default. However, in some cases it may be better to use ARIA roles instead. However, in this case there seemed to be no design implications with changing the markup from section to main so I opted to go that route.

Resources:
https://fae.disability.illinois.edu/rulesets/LANDMARK_1/