### PR TITLE
Remove tabindex from submit button

### DIFF
--- a/source/contact.html
+++ b/source/contact.html
@@ -36,7 +36,7 @@
         <span>Please enter the characters from the image.</span>
       </div>
       <div class="contact_send">
-        <button type="submit" name="submit" title="Send message" tabindex="6">Send message</button>
+        <button type="submit" name="submit" title="Send message">Send message</button>
       </div>
     </form>
   {% endif %}


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169763821

Accessibility best practices dictate that elements should not have tabindex greater than zero. Using tabindex with a value greater than 0 creates an unexpected tab order, making the page less intuitive and can give the appearance of skipping certain elements entirely. This removes tabindex from the submit button and relies on the page's default tab order.

This change is also associated with this PR in dugway: https://github.com/bigcartel/dugway/pull/172

Resources:
https://dequeuniversity.com/rules/axe/3.3/tabindex?application=AxeChrome