### PR TITLE
Update aria-label and title based on if the hamburger menu is open or closed

### DIFF
--- a/source/javascripts/store.js
+++ b/source/javascripts/store.js
@@ -10,6 +10,13 @@ $(function() {
     e.preventDefault();
     $(this).toggleClass('open');
     $('aside').toggleClass('open');
+    if($(this).hasClass('open')) {
+      $(this).attr('title', $(this).data('close'));
+      $(this).attr('aria-label', $(this).data('close'));
+    } else {
+      $(this).attr('title', $(this).data('open'));
+      $(this).attr('aria-label', $(this).data('open'));
+    }
   });
   $('.remove a').click(function(e) {
     e.preventDefault();

--- a/source/layout.html
+++ b/source/layout.html
@@ -9,7 +9,7 @@
   </head>
   <body id="{{ page.permalink }}-page" class="{{ page.permalink }} {{ page.category }}">
     <div class="mobile_nav">
-      <a class="open_menu" href="#" title="Menu">
+      <a class="open_menu" role="button" href="#" data-open="Open Menu" data-close="Close Menu" title="Open Menu" aria-label="Open Menu">
         <span></span>
         <span></span>
         <span></span>


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169552905

The user should be able to distinguish between the hamburger icon and the "x"-icon and understand what each link is for. In this case, it dynamically updates the aria-label and title to say whether it's for "Open Menu" or "Close Menu." This also assigns a role of "button."