### PR TITLE
Update text sizes on cart

### DIFF
--- a/source/stylesheets/_config.sass
+++ b/source/stylesheets/_config.sass
@@ -17,6 +17,8 @@ $break-medium: 800px
 $break-small: 640px
 $break-extra-small: 500px
 
+$text-size: 16px
+
 @mixin border-radius($radius...)
   border-radius: $radius
 

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -10,7 +10,7 @@
       +pie-clearfix
       border-bottom: 1px solid $border-color
       display: block
-      font-size: 14px
+      font-size: $text-size
       height: 120px
       line-height: 15px
       overflow: hidden
@@ -60,7 +60,7 @@
           span
             color: $text-color
             display: block
-            font-size: 13px
+            font-size: 14px
             line-height: 1.4em
             margin-top: 5px
 
@@ -85,7 +85,7 @@
             input[type='text']
               +border-radius(2px)
               height: 46px
-              font-size: 14px
+              font-size: $text-size
               text-align: center
               text-indent: 0
               width: 56px
@@ -136,7 +136,7 @@
       font-weight: 500
       margin: 0
       padding: 0
-      font-size: 22px
+      font-size: 24px
       line-height: 22px
       margin-bottom: 40px
       text-align: right

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -537,7 +537,7 @@ button, a.button
   cursor: pointer
   display: inline-block
   font-family: $secondary-font
-  font-size: 14px
+  font-size: $text-size
   height: 50px
   line-height: 46px
   outline: none
@@ -548,7 +548,7 @@ button, a.button
     background: none
     color: $text-color
     border: none
-    font-size: 13px
+    font-size: 15px
     padding: 0
 
     &:not(:disabled):hover, &:not(:disabled):active, &:not(:disabled):focus


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169840430

Increases the font size on various cart elements to have accessible
color contrast ratios. This also creates a new $text-size variable set
to 16px.