### PR TITLE
Side navigation color contrast updates

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -45,7 +45,7 @@
         </a>
         <nav role="navigation" aria-label="Main">
           <div class="side_categories">
-            <h2>Shop</h2>
+            <div class="nav_title">Shop</div>
             <ul>
               <li><a href="/products">All Products</a></li>
               {% if theme.show_search %}
@@ -64,7 +64,7 @@
           </div>
           {% if artists.active != blank %}
             <div class="side_artists">
-              <h2>Artists</h2>
+              <div class="nav_title">Artists</div>
               <ul>
                 {% for artist in artists.active %}
                   <li>{{ artist | link_to }}</li>
@@ -76,7 +76,7 @@
             {% get 5 products from products.all order: 'newest' %}
               {% if products != blank %}
                 <div class="side_pages">
-                  <h2>Newest Products</h2>
+                  <div class="nav_title">Newest Products</div>
                   <ul>
                           {% for product in products %}
                             <li>{{ product | link_to }}</li>
@@ -90,7 +90,7 @@
             {% get 5 products from products.all order: 'sales' %}
               {% if products != blank %}
                 <div class="side_pages">
-                  <h2>Top Selling</h2>
+                  <div class="nav_title">Top Selling</div>
                   <ul>
                           {% for product in products %}
                             <li>{{ product | link_to }}</li>
@@ -101,7 +101,7 @@
             {% endget %}
           {% endif %}
           <div class="side_pages">
-            <h2>Pages</h2>
+            <div class="nav_title">Pages</div>
             <ul>
               {% for page in pages.all %}
                   <li>{{ page | link_to }}</li>

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -311,7 +311,7 @@ aside
   .nav_title
     color: $header-color
     border-bottom: 1px solid $border-color
-    font-size: 17px
+    font-size: 20px
     line-height: 1.3em
     margin-bottom: 4px
     padding: 0 0 6px
@@ -324,7 +324,7 @@ aside
     color: $button-color
     display: block
     font-family: $secondary-font
-    font-size: 14px
+    font-size: 15px
     height: 50px
     margin-bottom: 40px
     padding: 0 10px
@@ -383,7 +383,7 @@ aside
       bottom: 6px
       color: $link-color
       cursor: pointer
-      font-size: 14px
+      font-size: 15px
       position: absolute
 
       &:hover
@@ -414,8 +414,8 @@ aside
 
       a
         display: block
-        font-size: 14px
-        padding: 5px 0
+        font-size: 15px
+        padding: 8px 0
         line-height: 18px
 
   nav > div

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -308,7 +308,8 @@ aside
     visibility: visible
     z-index: 9
 
-  h2
+  .nav_title
+    color: $header-color
     border-bottom: 1px solid $border-color
     font-size: 17px
     line-height: 1.3em


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169818783

This updates the font size and padding to the global side nav to make it more readable. Also, since the navigation titles aren't part of the main content, the use of headings would not be appropriate here. I've replaced them with divs instead.