### PR TITLE
Fix mobile menu spacing

### DIFF
--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -291,6 +291,7 @@ aside
     top: 0
     visibility: hidden
     width: 100%
+    margin: auto
 
   &.open
     +all-transitions


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/169818783

On mobile / small screens, the menu lost its margin. This add it back in.