### PR TITLE
Set contact text area to display:block

### DIFF
--- a/source/stylesheets/contact.sass
+++ b/source/stylesheets/contact.sass
@@ -21,8 +21,9 @@
   
   textarea  
     height: 300px
-  
-  label  
+    display: block
+
+  label
     display: block
     font-size: 16px
     margin-bottom: 10px


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/170077740

There was extra spacing between the tex area and spam check label. Setting text area to display: block fixes the issue.