### PR TITLE
fix: remove margin-bottom on header

### DIFF
--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -200,7 +200,6 @@ header
   font-family: var(--primary-font)
   font-size: 28px
   padding: 48px 0
-  margin-bottom: 32px
   text-align: center
 
   @media only screen and (max-width: $break-large)


### PR DESCRIPTION
Appears to be an extra 32px margin-bottom on the header that's not needed.  Came up from a few sellers recently wondering about vertical alignment of their header logo.

![image](https://github.com/user-attachments/assets/6ef762bf-e244-4206-b855-6a0f5daea605)
