### PR TITLE
Remove share buttons on product page

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -277,7 +277,6 @@
       <script>
         Product.find('{{ product.permalink }}', processProduct)
       </script>
-      <script async defer src="//assets.pinterest.com/js/pinit.js"></script>
     {% endif %}
   </body>
 </html>

--- a/source/product.html
+++ b/source/product.html
@@ -164,21 +164,4 @@
 			{{ product.description | paragraphs }}
 		{% endif %}
 	</div>
-  {% if theme.show_share_buttons %}
-    <ul class="share_buttons">
-      <li class="social_twitter">
-        {% capture tweet_string %}{{ product.name }} - {{ store.name }} {{ page.full_url }}{% endcapture %}
-        {% assign tweet_string = tweet_string | url_encode %}
-        <a title="Tweet" aria-label="Tweet" href="https://twitter.com/intent/tweet?text={{ tweet_string }}" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=no,scrollbars=no,height=400,width=600');return false;"><svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 150.857 612 490.298"><path d="M606 209c-22.2 9.7-46 16.4-70.8 19.4 25.4-15.3 45-39.6 54-68.5-23.7 14-50 24-78 30-22.5-24-54.4-39-89.8-39-68 0-123 55-123 123 0 9.3 1 19 3 28-102.2-5-192.8-54-253.4-129-11 18.3-17 39.5-17 62.2 0 43 21.5 81 54.6 103-20.2-.6-39.2-6-55.8-15.4v2c0 60 42.3 110 98.6 121.2-10.4 3-21.3 4.6-32.5 4.6-8 0-16-1-23-2.5 15 49.3 61 85 115 86-42 33.3-96 53-153 53-10 0-20-.5-30-1.7 55 35 119.5 55.5 189 55.5 226.3 0 350-188.5 350-352 0-5.5 0-10.8-.3-16 24-17.6 45-39.4 61.4-64z"/></svg>
-        </a>
-      </li>
-      <li class="social_facebook">
-        <a title="Share on Facebook" aria-label="Share on Facebook" href="https://www.facebook.com/sharer/sharer.php?u={{store.url}}{{product.url}}" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=no,scrollbars=no,height=400,width=600');return false;"><svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="157.162 90 297.799 612"><path d="M369.036 193.795h85.68V90H333.662c-97.553 19.707-98.776 108.936-98.776 108.936V304.69h-77.724v102.937h77.724V702H343.21V407.383h102.08l9.67-102.938H343.945v-75.52c-.123-33.172 25.092-35.13 25.092-35.13z"/></svg></a>
-      </li>
-      <li class="social_pinterest">
-        <a title="Pin" aria-label="Pin" data-pin-custom="true" data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/?url={{ page.full_url }}&media={{ product.images.first.url }}&description={{ product.description | escape | truncate: 200 }}"><svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 12 16"><path d="M4.933 10.582c-.406 2.203-.9 4.314-2.366 5.418-.452-3.33.665-5.83 1.183-8.484C2.866 6 3.9 2.9 5.7 3.63c2.315.97-2 5.77.9 6.34 3 .6 4.225-5.4 2.365-7.36C6.285-.22 1.1 2.5 1.8 6.596c.154 1 1.1 1.3.4 2.658C.48 8.858-.034 7.45.032 5.574.138 2.504 2.692.352 5.255.054c3.24-.376 6.3 1.2 6.7 4.396.473 3.568-1.462 7.433-4.927 7.2C6.063 11.5 5.7 11 4.9 10.582z"/></svg>
-        </a>
-      </li>
-    </ul>
-  {% endif %}
 </section>

--- a/source/settings.json
+++ b/source/settings.json
@@ -394,13 +394,6 @@
       "requires": "inventory"
     },
     {
-      "variable": "show_share_buttons",
-      "label": "Show Product share buttons",
-      "type": "boolean",
-      "default": true,
-      "description": "Adds Facebook, Twitter, and Pinterest buttons to Product pages"
-    },
-    {
       "variable": "border_radius",
       "label": "Rounded corners",
       "type": "select",

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -107,42 +107,6 @@ button.reset-selection-button
     .add-to-cart-button
       width: 100%
 
-.share_buttons
-
-  @media only screen and (max-width: $break-medium)
-    text-align: center
-
-  li
-    display: inline-block
-    margin-right: 20px
-    position: relative
-
-    @media screen and (max-width: $break-medium)
-      margin: 0 8px
-
-    a
-      cursor: pointer
-      display: block
-
-      svg
-        fill: currentColor
-        height: 20px
-        width: 20px
-
-    &.social_pinterest
-
-      a
-        display: inline-block
-        position: relative
-
-        &:after
-          content: ""
-          position: absolute
-          top: 0
-          right: 0
-          bottom: 0
-          left: 0
-
 .product-form
   max-width: 350px
   width: 100%


### PR DESCRIPTION
Engagement on these types of Share buttons continues to decrease year over year, so the button is being removed. Instead, visitors can copy/paste URLs, use browser plugins, or use the native share tools on mobile browsers.