### PR TITLE
chore: add data hook and page type to Layout

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -8,7 +8,7 @@
     {{ head_content }}
     <style type="text/css">.preload * { opacity: 0 } .transition-preload * { transition:none!important; }</style>
   </head>
-  <body id="{{ page.permalink }}" class="{{ page.permalink }} {{ page.category }} preload transition-preload">
+  <body id="{{ page.permalink }}" class="{{ page.permalink }} {{ page.category }} preload transition-preload" data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
     {% if theme.announcement_message_text != blank %}
       <div aria-label="Announcement message" class="announcement-message">
         <div class="announcement-message__text">{{ theme.announcement_message_text }}</div>
@@ -32,7 +32,7 @@
         <span class="sr-only">View cart - </span><span class="cart_title">{{ cart.item_count | pluralize: 'item', 'items' }}</span>/<span class="cart_numbers">{{ cart.total | money: theme.money_format }}</span>
       </a>
   	</div>
-    <header class="{% if theme.header_logo != blank %}logo{% else %}text{% endif %}">
+    <header class="{% if theme.header_logo != blank %}logo{% else %}text{% endif %}" data-bc-hook="header">
   		<div class="inner-wrapper">
         <a href="/" title="{{ store.name | escape }}" class="store_header {% if theme.header_logo != blank %}logo{% else %}text{% endif %}">
       		{% if theme.header_logo != blank %}
@@ -145,7 +145,7 @@
         </main>
       {% endif %}
     </div>
-    <footer role="contentinfo">
+    <footer role="contentinfo" data-bc-hook="footer">
       <div class="inner-wrapper">
         {% if theme.instagram_url != blank
           or theme.tiktok_url != blank

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Lunch Break",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "images": [
     {
       "variable": "header_logo",


### PR DESCRIPTION
Allows for 3rd party apps to target key regions for adding content. In particular, key for omnisend and email partners to be able to insert content above the footer.

1. Adds `data-bc-hook` attribute to header and footer
2. Adds `data-bc-page-type` attribute to the body tag

Note: A much larger change was previously proposed but I've scaled it back to only the above 2 changes foregoing the larger change which is much more complex.
