### PR TITLE
Lunch Break v1.23.6

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -168,8 +168,14 @@
             {% assign show_more_section = true %}
           {% elsif pages.subscribe_page %}
             {% assign show_more_section = true %}
-          {% elsif theme.nav_page_display != "none" %}
+          {% elsif store.website != blank %}
             {% assign show_more_section = true %}
+          {% elsif theme.nav_page_display == "all" or theme.nav_page_display == "contact_only" %}
+            {% assign show_more_section = true %}
+          {% elsif theme.nav_page_display == "pages_only" %}
+            {% if pages.custom_pages.size > 0 and theme.nav_items_footer > 0 %}
+              {% assign show_more_section = true %}
+            {% endif %}
           {% endif %}
 
           {% if show_more_section %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Lunch Break",
-  "version": "1.23.5",
+  "version": "1.23.6",
   "images": [
     {
       "variable": "logo_image",


### PR DESCRIPTION
Fixes bug where "More" section would show with no content when:
- nav_page_display is "pages_only"
- No custom pages exist OR nav_items_footer is set to 0
- No other content (subscribe, website, required pages, contact)

The section now only displays when actual navigation links will render.