### PR TITLE
Lunch Break v1.24.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -46,9 +46,33 @@
               </a>
               <div class="option-name">
                 {% unless item.product.has_default_option %}
-                  {{ item.option.name }} - <span class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</span>
+                  {{ item.option.name }} - <span class="cart-item-unit-price">
+                    {% assign show_strikethrough = false %}
+                    {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                      {% assign show_strikethrough = true %}
+                    {% endif %}
+
+                    {% if show_strikethrough %}
+                      <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ item.unit_price | money: theme.money_format }}
+                    {% endif %}
+                  </span>
                 {% else %}
-                  <div class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</div>
+                  <div class="cart-item-unit-price">
+                    {% assign show_strikethrough = false %}
+                    {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                      {% assign show_strikethrough = true %}
+                    {% endif %}
+
+                    {% if show_strikethrough %}
+                      <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ item.unit_price | money: theme.money_format }}
+                    {% endif %}
+                  </div>
                 {% endunless %}
               </div>
             </div>

--- a/source/home.html
+++ b/source/home.html
@@ -153,7 +153,32 @@
                     {% endif %}
 
                     {% unless hide_price %}
-                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% assign show_strikethrough = false %}
+                      {% assign strikethrough_regular = nil %}
+                      {% assign strikethrough_sale = nil %}
+
+                      {% if theme.show_strikethrough_pricing %}
+                        {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.original_price %}
+                          {% assign strikethrough_sale = product.default_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.min_original_price %}
+                          {% assign strikethrough_sale = product.min_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.max_original_price %}
+                          {% assign strikethrough_sale = product.max_price %}
+                        {% endif %}
+                      {% endif %}
+
+                      {% if show_strikethrough %}
+                        <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                        <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                      {% else %}
+                        {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% endif %}
 
                       {% if product.price_suffix != blank %}
                         {% assign variable_price_shown = true %}

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -167,10 +167,13 @@ processUpdate = (input, item_id, new_val, cart) => {
   if (new_val > 0) {
     for (itemIndex = 0; itemIndex < cart.items.length; itemIndex++) {
       if (cart.items[itemIndex].id == item_id) {
-        item_price = cart.items[itemIndex].price;
-        formatted_item_price = formatMoney(item_price, true, true);
-        let priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
-        htmlHighlight(priceElement,formatted_item_price);
+        var item = cart.items[itemIndex];
+        var item_price = item.price;
+        var priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
+
+        // Line total only shows sale price (no strikethrough - strikethrough is on unit price only)
+        var formattedPrice = formatMoney(item_price, true, true);
+        htmlHighlight(priceElement, formattedPrice);
       }
     }
   }

--- a/source/javascripts/product-option-groups.js
+++ b/source/javascripts/product-option-groups.js
@@ -305,7 +305,7 @@ function processAvailableDropdownOptions(product, changed_dropdown) {
     if (product_option) {
       if (!product_option.sold_out && product_option.id > 0) {
         $('#option').val(product_option.id);
-        enableAddButton(product_option.price);
+        enableAddButton(product_option.price, product_option.original_price);
         if (num_option_groups > 1) {
           $('.reset-selection-button').fadeIn('fast');
         }

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -29,8 +29,10 @@ if (themeOptions.productImageZoom === true) {
   lightbox.init();
 }
 $('.product_option_select').on('change',function() {
-  var option_price = $(this).find("option:selected").attr("data-price");
-  enableAddButton(option_price);
+  var selectedOption = $(this).find("option:selected");
+  var option_price = selectedOption.attr("data-price");
+  var original_price = selectedOption.attr("data-original-price");
+  enableAddButton(option_price, original_price);
 });
 
 function updateInventoryMessage(optionId = null) {
@@ -92,33 +94,84 @@ function updateInventoryMessage(optionId = null) {
   }
 }
 
-function enableAddButton(updated_price) {
+function updateButtonPrice(priceElement, updated_price, original_price) {
+  var updatedNum = parseFloat(updated_price) || 0;
+  var originalNum = parseFloat(original_price) || 0;
+  var showStrikethrough = originalNum > updatedNum && themeOptions.showStrikethroughPricing;
+
+  var priceHtml;
+  if (showStrikethrough) {
+    var originalFormatted = formatMoney(original_price, true, true);
+    var saleFormatted = formatMoney(updated_price, true, true);
+    priceHtml = '<s class="price-compare">' + originalFormatted + '</s> <span class="price-sale">' + saleFormatted + '</span>';
+  } else {
+    priceHtml = formatMoney(updated_price, true, true);
+  }
+  priceElement.html(priceHtml);
+}
+
+function enableAddButton(updated_price, original_price) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
-  addButton.attr("disabled",false);
+  var addButtonTextElement = addButton.find('.button-add-text');
+  var addButtonPriceElement = addButton.find('.button-add-price');
+
+  addButton.attr("disabled", false);
+  addButtonTextElement.html(addButtonTitle);
+  addButton.attr('aria-label', addButtonTitle);
+
+  // On mobile, the price display is far from the button due to the product image between them.
+  // Show the price in the button so users see price changes when selecting options.
   if (updated_price) {
-    priceTitle = ' - ' + formatMoney(updated_price, true, true);
+    updateButtonPrice(addButtonPriceElement, updated_price, original_price);
+    addButtonPriceElement.addClass('visible');
+  } else {
+    addButtonPriceElement.removeClass('visible');
   }
-  else {
-    priceTitle = '';
-  }
-  addButton.html(addButtonTitle + priceTitle);
-  addButton.attr('aria-label',addButton.text());
+
   updateInventoryMessage($('#option').val());
+  updateProductPrice(updated_price, original_price);
   showBnplMessaging(updated_price, { alignment: 'left', displayMode: 'grid', pageType: 'product' });
+}
+
+function updateProductPrice(updated_price, original_price) {
+  var priceContainer = $('.product_price-value');
+  if (!priceContainer.length) return;
+
+  // Convert to numbers for proper comparison (data attributes are strings)
+  var updatedNum = parseFloat(updated_price) || 0;
+  var originalNum = parseFloat(original_price) || 0;
+
+  var showStrikethrough = originalNum > updatedNum &&
+                          themeOptions.showStrikethroughPricing;
+
+  var priceHtml;
+  if (showStrikethrough) {
+    var regularFormatted = formatMoney(original_price, true, true);
+    var saleFormatted = formatMoney(updated_price, true, true);
+    priceHtml = '<s class="price-compare">' + regularFormatted + '</s> <span class="price-sale">' + saleFormatted + '</span>';
+  } else {
+    priceHtml = formatMoney(updated_price, true, true);
+  }
+
+  priceContainer.html(priceHtml);
 }
 
 function disableAddButton(type) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
+  var addButtonTextElement = addButton.find('.button-add-text');
+  var addButtonPriceElement = addButton.find('.button-add-price');
+
   if (type == "sold-out") {
-    var addButtonTitle = addButton.attr('data-sold-title');
+    addButtonTitle = addButton.attr('data-sold-title');
   }
   if (!addButton.is(":disabled")) {
-    addButton.attr("disabled","disabled");
+    addButton.attr("disabled", "disabled");
   }
-  addButton.html(addButtonTitle);
-  addButton.attr('aria-label','');
+  addButtonTextElement.html(addButtonTitle);
+  addButtonPriceElement.removeClass('visible');
+  addButton.attr('aria-label', '');
 }
 
 function enableSelectOption(select_option) {

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -138,6 +138,17 @@ function updateProductPrice(updated_price, original_price) {
   var priceContainer = $('.product_price-value');
   if (!priceContainer.length) return;
 
+  if (!updated_price) {
+    if (priceContainer.data('original-html') !== undefined) {
+      priceContainer.html(priceContainer.data('original-html'));
+    }
+    return;
+  }
+
+  if (priceContainer.data('original-html') === undefined) {
+    priceContainer.data('original-html', priceContainer.html());
+  }
+
   // Convert to numbers for proper comparison (data attributes are strings)
   var updatedNum = parseFloat(updated_price) || 0;
   var originalNum = parseFloat(original_price) || 0;

--- a/source/layout.html
+++ b/source/layout.html
@@ -388,9 +388,34 @@
                         {% endif %}
 
                         {% unless hide_price %}
-                            {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                            {% assign show_strikethrough = false %}
+                            {% assign strikethrough_regular = nil %}
+                            {% assign strikethrough_sale = nil %}
 
-                            {% if product.price_suffix != blank %}
+                            {% if theme.show_strikethrough_pricing %}
+                              {% if related_product.variable_pricing == false and related_product.original_price > related_product.default_price %}
+                                {% assign show_strikethrough = true %}
+                                {% assign strikethrough_regular = related_product.original_price %}
+                                {% assign strikethrough_sale = related_product.default_price %}
+                              {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and related_product.min_original_price > related_product.min_price %}
+                                {% assign show_strikethrough = true %}
+                                {% assign strikethrough_regular = related_product.min_original_price %}
+                                {% assign strikethrough_sale = related_product.min_price %}
+                              {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and related_product.max_original_price > related_product.max_price %}
+                                {% assign show_strikethrough = true %}
+                                {% assign strikethrough_regular = related_product.max_original_price %}
+                                {% assign strikethrough_sale = related_product.max_price %}
+                              {% endif %}
+                            {% endif %}
+
+                            {% if show_strikethrough %}
+                              <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                              <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                            {% else %}
+                              {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                            {% endif %}
+
+                            {% if related_product.price_suffix != blank %}
                               {% assign variable_price_shown = true %}
                               {% if theme.product_variable_pricing_display_format == "min_only" or theme.product_variable_pricing_display_format == "max_only" %}
                                 {% assign variable_price_shown = false %}
@@ -583,6 +608,7 @@
         homepageSlideshowTransition: "{{ theme.homepage_slideshow_transition }}",
         homepageSlideshowLink: "{{ theme.homepage_slideshow_link }}",
         showBnplMessaging: {{ theme.show_bnpl_messaging }} && !themeFeatures.optOuts.includes("theme_bnpl_messaging"),
+        showStrikethroughPricing: {{ theme.show_strikethrough_pricing }},
         homeFeaturedVideoUrl: "{{ theme.home_featured_video_url }}",
         homeFeaturedVideoSize: "{{ theme.home_featured_video_size }}",
         homeFeaturedVideoBorder: "{{ theme.home_featured_video_border }}",

--- a/source/product.html
+++ b/source/product.html
@@ -11,7 +11,35 @@
     <div class="product_price_status">
       <span class="product_price {% unless hide_price %}with-spacing{% endunless %}">
         {% unless hide_price %}
-          {{ product | product_price: theme.money_format }}
+          {% capture product_pricing %}
+            {% assign show_strikethrough = false %}
+            {% assign strikethrough_regular = nil %}
+            {% assign strikethrough_sale = nil %}
+
+            {% if theme.show_strikethrough_pricing %}
+              {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                {% assign show_strikethrough = true %}
+                {% assign strikethrough_regular = product.original_price %}
+                {% assign strikethrough_sale = product.default_price %}
+              {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                {% assign show_strikethrough = true %}
+                {% assign strikethrough_regular = product.min_original_price %}
+                {% assign strikethrough_sale = product.min_price %}
+              {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                {% assign show_strikethrough = true %}
+                {% assign strikethrough_regular = product.max_original_price %}
+                {% assign strikethrough_sale = product.max_price %}
+              {% endif %}
+            {% endif %}
+
+            {% if show_strikethrough %}
+              <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+              <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+            {% else %}
+              {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+            {% endif %}
+          {% endcapture %}
+          <span class="product_price-value">{{ product_pricing }}</span>
 
           {% if product.price_suffix != blank %}
             {% assign variable_price_shown = true %}
@@ -181,7 +209,26 @@
                   <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
                     <option value="" disabled="disabled" selected>{{ option_group.name }}</option>
                     {% for value in option_group.values %}
-                      <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}</option>
+                      {% comment %}
+                        For single option groups, we can show status labels since each value maps to one product option.
+                        For multiple option groups, we can't know status until all selections are made.
+                      {% endcomment %}
+                      {% assign option_status_label = '' %}
+                      {% if product.option_groups.size == 1 %}
+                        {% for option in product.options %}
+                          {% for ogv in option.option_group_values %}
+                            {% if ogv.id == value.id %}
+                              {% if option.sold_out %}
+                                {% assign option_status_label = t['products.sold_out'] | downcase %}
+                              {% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %}
+                                {% assign option_status_label = t['products.on_sale'] | downcase %}
+                              {% endif %}
+                              {% break %}
+                            {% endif %}
+                          {% endfor %}
+                        {% endfor %}
+                      {% endif %}
+                      <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}{% if option_status_label != blank %} ({{ option_status_label }}){% endif %}</option>
                     {% endfor %}
                   </select>
                   <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 7.6" enable-background="new 0 0 15 7.6"><path d="M15 1.1l-7.5 6.5-7.5-6.3 1-1.2 6.5 5.5 6.5-5.6z"/></svg>
@@ -193,14 +240,17 @@
               <select class="product_option_select" id="option" name="cart[add][id]" aria-label="{{ t['products.select_variant'] }}" required>
                 <option value="" disabled="disabled" selected>{{ t['products.select_variant'] }}</option>
                 {% for option in product.options %}
-                  <option value="{{ option.id }}" data-price="{{ option.price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} ({{ t['products.sold_out'] }}){% endif %}</option>
+                  <option value="{{ option.id }}" data-price="{{ option.price }}" data-original-price="{{ option.original_price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }}{% if option.sold_out %} ({{ t['products.sold_out'] }}){% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %} ({{ t['products.on_sale'] | downcase }}){% endif %}</option>
                 {% endfor %}
               </select>
               <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 7.6" enable-background="new 0 0 15 7.6"><path d="M15 1.1l-7.5 6.5-7.5-6.3 1-1.2 6.5 5.5 6.5-5.6z"/></svg>
             </div>
           {% endif %}
         {% endif %}
-        <button id="add-to-cart-button" class="button add-to-cart-button" type="submit" data-add-title="{{ t['products.add_to_cart'] }}" data-sold-title="{{ t['products.sold_out'] }}">{{ t['products.add_to_cart'] }}</button>
+        <button id="add-to-cart-button" class="button add-to-cart-button" type="submit" data-add-title="{{ t['products.add_to_cart'] }}" data-sold-title="{{ t['products.sold_out'] }}"{% if product.has_default_option %} data-selected-price="{{ product.default_price }}" data-selected-original-price="{{ product.original_price }}"{% endif %}>
+          <span class="button-add-price{% if product.has_default_option %} visible{% endif %}">{{ product.default_price | money: theme.money_format }}</span>
+          <span class="button-add-text">{{ t['products.add_to_cart'] }}</span>
+        </button>
         {{ store | instant_checkout_button: 'dark', '44px' }}
         <div class="inventory-status-message" data-inventory-message></div>
         {% if product.has_option_groups %}

--- a/source/products.html
+++ b/source/products.html
@@ -75,7 +75,32 @@
                   {% endif %}
 
                   {% unless hide_price %}
-                    {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                    {% assign show_strikethrough = false %}
+                    {% assign strikethrough_regular = nil %}
+                    {% assign strikethrough_sale = nil %}
+
+                    {% if theme.show_strikethrough_pricing %}
+                      {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.original_price %}
+                        {% assign strikethrough_sale = product.default_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.min_original_price %}
+                        {% assign strikethrough_sale = product.min_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.max_original_price %}
+                        {% assign strikethrough_sale = product.max_price %}
+                      {% endif %}
+                    {% endif %}
+
+                    {% if show_strikethrough %}
+                      <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                    {% endif %}
 
                     {% if product.price_suffix != blank %}
                       {% assign variable_price_shown = true %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -951,6 +951,25 @@
       }
     },
     {
+      "variable": "show_strikethrough_pricing",
+      "label": "Show strikethrough pricing",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the original price crossed out next to the sale price",
+      "requires": [
+        "feature:theme_strikethrough_pricing eq visible"
+      ]
+    },
+    {
+      "variable": "show_sale_label_in_product_options",
+      "label": "Show sale label in variant dropdowns",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Adds a sale indicator next to discounted variants in the dropdown"
+    },
+    {
       "variable": "product_variable_pricing_display_format",
       "label": "Price display for products with varying prices",
       "section": "product_page",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Lunch Break",
-  "version": "1.23.7",
+  "version": "1.24.0",
   "images": [
     {
       "variable": "logo_image",

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -526,7 +526,7 @@ header
       transition: opacity 0.2s ease
       
       &:hover
-        opacity: 0.7
+        opacity: 0.6
         
     svg
       width: 22px

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -146,6 +146,25 @@ button.reset-selection-button
     .add-to-cart-button
       width: 100%
 
+.button-add-price
+  display: none
+
+.add-to-cart-button:has(.button-add-price.visible)
+  @media (max-width: $break-medium)
+    display: flex
+    flex-direction: column
+    align-items: center
+    height: auto
+    padding: 12px 15px
+
+    .button-add-price
+      display: block
+      margin-bottom: 4px
+      font-size: 0.875rem
+
+    .button-add-text
+      font-size: 1rem
+
 .product-form
   max-width: 350px
   width: 100%

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -96,6 +96,12 @@
 .price-suffix
   white-space: nowrap
 
+// Strikethrough pricing styles
+.price-compare
+  text-decoration: line-through
+  opacity: 0.6
+  margin-right: 0.3em
+
 .product-list-thumb-options-description
   font-size: calc(0.85em * var(--product-grid-scale, 1))
 


### PR DESCRIPTION
## Summary

### Features
- **Strikethrough pricing** — Display original prices with strikethrough when items are on sale
- **Titlecase nav text transformation** — New option to apply titlecase formatting to navigation text

### Fixes
- **Product description container always in DOM** — The product description container is now always rendered (with a `data-bc-hook`) so it can be targeted by JS, and hidden via CSS `:empty` when there's no description

### Chores
- Lowercase label for options text in product grid
- Version bump to 1.24.0